### PR TITLE
issues-194 : Initial docker development environment image and docs

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout 
+        uses: actions/checkout@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/devenv:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+site-docs-wip.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18-alpine3.14
+
+ARG WORKSPACE_DIR=/evidence-workspace 
+
+RUN apk add --no-cache bash curl wget nano git && \
+    npm install -g degit && \
+    mkdir -p ${WORKSPACE_DIR} && \
+    mkdir -p /evidence-bin
+
+COPY bootstrap.sh /evidence-bin/bootstrap.sh
+WORKDIR ${WORKSPACE_DIR}
+
+ENTRYPOINT [ "bash", "/evidence-bin/bootstrap.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,13 @@
-# docker-devenv
+# Docker Development Environment
 
 This repository builds the Evidence development environment Docker image. An instance container can be used as a development environment for Evidence projects using a mounted directory.  Using this container allows end users to develop Evidence sites without the need for installing any toolchains besides `Docker`.
 
 ## Pre-requisites
 Docker tools are installed using [Docker Desktop](https://www.docker.com/products/docker-desktop/) (recommended) OR using [binaries](https://docs.docker.com/engine/install/binaries/).
 
-## Building and running the image locally 
-* This only applies to the development of this Docker image.
+## Running the development environment using Docker commands (Alternative 1)
 
-```
-docker build -t <image-name> .
-cd <path-to-your-evidence-project-root>
-docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --rm <image-name> <command-to-run>
-```
-## Running a devenv container using the latest published image
-
-* Option 1: Work with an existing Evidence project
+* Work with an existing Evidence project
 ```
     cd <path-to-your-evidence-project-root>
     docker pull evidencedev/devenv:latest
@@ -24,7 +16,7 @@ docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --rm <image-name> <com
     # - You should see your site up when you point your browser to localhost:3000. 
     # - Any edits made in <path-to-your-evidence-project-root> should be reflected on the browser.
 ```
-* Option 2: Creating a new evidence project from scratch using the Evidence project template
+* Creating a new evidence project from scratch using the Evidence project template
 ```
     cd <path-to-your-evidence-project-root> #i.e the directory where you'd like your Evidence project to be rooted
     docker pull evidencedev/devenv:latest
@@ -35,13 +27,20 @@ docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --rm <image-name> <com
     # - Any subsequent edits made in <path-to-your-evidence-project-root> should be reflected on the browser.
 
 ```
+Note: if you are running Evidence from a new Apple Silicon MacBook (or any machine with an `arm` chipset), you'll have to provide a `--platform linux/amd64` argument to Docker as well.
 
-## Using the helper script to run the latest published image
-`start-devenv.sh` in this repository is a helper script to start up the latest published Docker image. It simply reduces the verbosity needed to startup a docker container as described in the previous section.  
+## Running the development environment using a helper script (Alternative 2)
+* Download `https://github.com/evidence-dev/docker-devenv/blob/main/start-devenv.sh` and copy it to your Evidence project root. Then execute the following commands to run your existing project in the Docker development environment.
+```
+    cd <path-to-your-evidence-project-root>
+    chmod +x start-devenv.sh
+    ./start-devenv.sh
+```
+To start a new Evidence project, the steps are identical except you'd have to pass the `--init` option to the script, i.e `./start-devenv.sh --init`. 
 
-You'll typically download this script, and invoke this script from your Evidence project's root directory. Run `start-devenv.sh --help` for more info. Alternatively, you can run it directly `wget -O - https://github.com/evidence-dev/docker-devenv/blob/main/start-devenv.sh | bash`
+Run `start-devenv.sh --help` for more details on using this script. 
 
-As the project develops, we'll likely add more options here.
+As the project develops, we'll likely add more options to this script. This script simply masks all the options that need to be provided to `docker`.
 
 ## Connecting to a Dababase from the development container
 
@@ -58,3 +57,12 @@ If your database is hosted on your `host` machine, you'll have to ensure that th
 If your database is hosted externally (e.g on the cloud), you'll have to ensure your docker container has permissions to access the outside world.
 ## Stopping the running container
 Abort the terminal window  using `CTRL+C` or use the Docker [command line](https://docs.docker.com/engine/reference/commandline/stop/) or Docker Desktop to stop the running container.
+
+## Building and running the image locally 
+* This only applies to the development of this Docker image.
+
+```
+docker build -t <image-name> .
+cd <path-to-your-evidence-project-root>
+docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --rm <image-name> <command-to-run>
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
 # docker-devenv
-This repo builds a Docker image whose container instances can be used as a development environment for Evidence projects via a mounted directory
+
+This repository builds the Evidence development environment Docker image. An instance container can be used as a development environment for Evidence projects using a mounted directory.  Using this container allows end users to develop Evidence sites without the need for installing any toolchains besides `Docker`.
+
+## Pre-requisites
+Docker tools are installed using [Docker Desktop](https://www.docker.com/products/docker-desktop/) (recommended) OR using [binaries](https://docs.docker.com/engine/install/binaries/).
+
+## Building and running the image locally 
+* This only applies to the development of this Docker image.
+
+```
+docker build -t <image-name> .
+cd <path-to-your-evidence-project-root>
+docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --rm <image-name> <command-to-run>
+```
+## Running a devenv container using the latest published image
+
+* Option 1: Work with an existing Evidence project
+```
+    cd <path-to-your-evidence-project-root>
+    docker pull evidencedev/devenv:latest
+    docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --rm evidencedev/devenv:latest
+
+    # - You should see your site up when you point your browser to localhost:3000. 
+    # - Any edits made in <path-to-your-evidence-project-root> should be reflected on the browser.
+```
+* Option 2: Creating a new evidence project from scratch using the Evidence project template
+```
+    cd <path-to-your-evidence-project-root> #i.e the directory where you'd like your Evidence project to be rooted
+    docker pull evidencedev/devenv:latest
+    docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --rm evidencedev/devenv:latest --init
+
+    # - You should see the template site up when you point your browser to localhost:3000.
+    # - You should see new files, copied from the Evidence project template, in <path-to-your-evidence-project-root>.
+    # - Any subsequent edits made in <path-to-your-evidence-project-root> should be reflected on the browser.
+
+```
+
+## Using the helper script to run the latest published image
+`start-devenv.sh` in this repository is a helper script to start up the latest published Docker image. It simply reduces the verbosity needed to startup a docker container as described in the previous section.  
+
+You'll typically download this script, and invoke this script from your Evidence project's root directory. Run `start-devenv.sh --help` for more info. Alternatively, you can run it directly `wget -O - https://github.com/evidence-dev/docker-devenv/blob/main/start-devenv.sh | bash`
+
+As the project develops, we'll likely add more options here.
+
+## Connecting to a Dababase from the development container
+
+If your database is hosted on your `host` machine, you'll have to ensure that the Database host is set to `host.docker.internal` either via the settings or your database config file (instead of `localhost`, `0.0.0.0`, etc).  For instance:
+```
+{
+    "host": "host.docker.internal",
+    "database": "yourDBname",
+    "port": 5432,
+    "user": "yourUsername"
+}
+```
+
+If your database is hosted externally (e.g on the cloud), you'll have to ensure your docker container has permissions to access the outside world.
+## Stopping the running container
+Abort the terminal window  using `CTRL+C` or use the Docker [command line](https://docs.docker.com/engine/reference/commandline/stop/) or Docker Desktop to stop the running container.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+echo "Starting Evidence.dev development environment mounted on $(pwd) in the container."
+echo "Provided arguments => $@"
+
+RUN_DEV_COMMAND="npm run dev -- --host 0.0.0.0"
+COMMAND="npm install && $RUN_DEV_COMMAND"
+
+case $1 in
+    --init)
+        echo "Starting with a blank template project."
+        npx degit evidence-dev/template . && npm install
+        if [ $# -gt 1 ];
+        then
+            COMMAND=${@:2}
+        else
+            COMMAND=$RUN_DEV_COMMAND
+        fi
+        ;;
+    *)
+        if [ $# -gt 0 ];
+        then
+            COMMAND=$@
+        fi
+        ;;
+esac
+
+echo "Running command => $COMMAND"
+eval $COMMAND

--- a/start-devenv.sh
+++ b/start-devenv.sh
@@ -20,11 +20,13 @@ Help()
    echo "<any>         Executes <any> command after starting up the container (e.g bash)"
 }
 
+echo "Starting Evidence with project root set to $(pwd)"
+
 case $1 in
     --help)
       Help
         ;;
     *)
-        docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --rm $IMAGE_TAG $@
+        docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --platform linux/amd64 --rm $IMAGE_TAG $@
         ;;
 esac

--- a/start-devenv.sh
+++ b/start-devenv.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+IMAGE_TAG=evidencedev/devenv:latest
+
+Help()
+{
+   # Display Help
+   echo "This is a utility script to use $IMAGE_TAG Docker image as a development environment for Evidence."
+   echo "By default, running this script without any options results in working directory on the host mounted on the Docker container."
+   echo "Typically, the host's working directory should contain Evidence site files."
+   echo "You can use the --init option if you don't have a working Evidence project and would like to initialize new Evidence project from template." 
+   echo
+   echo "Syntax: ./start-devenv.sh [--help|--init|<any-command>]"
+
+   echo "options:"
+   echo "<no-options>  Work with an existing Evindence project rooted in the current working directory. This directory will be mounted on the devenv container."
+   echo "--init        Initializes a Evidence project template in the container. The working directory on your host machine is mounted to the Evidence working directory in the container."
+   echo "--init <any>  Same as --init but executed <any-command> right after new project initialization (e.g bash)"
+   echo "--help        Prints this help screen"
+   echo "<any>         Executes <any> command after starting up the container (e.g bash)"
+}
+
+case $1 in
+    --help)
+      Help
+        ;;
+    *)
+        docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --rm $IMAGE_TAG $@
+        ;;
+esac


### PR DESCRIPTION
Original Draft PR from [@aaronsteers](https://github.com/aaronsteers) https://github.com/evidence-dev/evidence/pull/230
Big thanks to AJ for the idea and the suggestions in the draft PR.  The README describes the background and how this works.

I pushed a locally build version of the image here -> https://hub.docker.com/repository/docker/evidencedev/devenv 
The image is about 200MB uncompressed (about 50MB compressed). Hence, the docs in the README.md should work as described as is.  Any subsequent pushes to main should trigger a github action to update the image.

