### PR TITLE
Install xdg-utils to support new vite version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:18-alpine3.14
-
+FROM node:19-alpine3.16
 ARG WORKSPACE_DIR=/evidence-workspace 
 
 RUN apk add --no-cache bash curl wget nano git && \
+    apk add xdg-utils && \
     npm install -g degit && \
     mkdir -p ${WORKSPACE_DIR} && \
     mkdir -p /evidence-bin

--- a/README.md
+++ b/README.md
@@ -83,4 +83,6 @@ Currently the image is hosted on Dockerhub. To build and publish a new version, 
 2. Build the image => `docker build -t evidencedev/devenv:latest .`
 3. Push the image to Dockerhub => `docker push evidencedev/devenv:latest`
 
-For login credentials, see `EvidenceDev Dockerhub Admin`.  This is setup under `udesh@evidence.dev` (didn't think to create a google group for this at the time e.g devs@evidence.dev - will do so in the future - feel free to use it in the meantime).
+For login credentials, see `EvidenceDev Dockerhub Admin` in 1password.  This is setup under `udesh@evidence.dev` (didn't think to create a google group for this at the time e.g devs@evidence.dev - will do so in the future - feel free to use it in the meantime). 
+
+We should consider hosting this in AWS with CD/CI setup to automatically publish new versions of the image from main

--- a/README.md
+++ b/README.md
@@ -76,3 +76,11 @@ docker build -t <image-name> .
 cd <path-to-your-evidence-project-root>
 docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --rm <image-name> <command-to-run>
 ```
+
+## Publishing the latest image to Docker Hub
+Currently the image is hosted on Dockerhub. To build and publish a new version, follow these steps
+1. Login to Dockerhub => `docker login`
+2. Build the image => `docker build -t evidencedev/devenv:latest .`
+3. Push the image to Dockerhub => `docker push evidencedev/devenv:latest`
+
+For login credentials, see `EvidenceDev Dockerhub Admin`.  This is setup under `udesh@evidence.dev` (didn't think to create a google group for this at the time e.g devs@evidence.dev - will do so in the future - feel free to use it in the meantime).


### PR DESCRIPTION
See https://github.com/evidence-dev/docker-devenv/issues/7
New vite version that we pulled in via SK upgrade appears to require `xdg-utils` to be installed 